### PR TITLE
Robust epics disconnect + display improvements

### DIFF
--- a/src/nbs_gui/models/base.py
+++ b/src/nbs_gui/models/base.py
@@ -342,12 +342,11 @@ class PVModelRO(BaseModel):
 
     def __init__(self, name, obj, group, long_name, **kwargs):
         super().__init__(name, obj, group, long_name, **kwargs)
-        print(f"Initializing PVModelRO for {name}")
         self._initialize()
 
     @initialize_with_retry
     def _initialize(self):
-        print(f"Initializing PVModelRO for {self.name}")
+        print(f"[{self.name}] Initializing PVModelRO")
         if not super()._initialize():
             self.value_type = None
             self.units = None
@@ -374,8 +373,11 @@ class PVModelRO(BaseModel):
             self.value_type = None
 
         self.sub_key = self.obj.subscribe(self._value_changed, run=False)
+        initial_value = self._get_value(check_connection=False)
+        self._value_changed(initial_value)
+        print(f"[{self.name}] Initial value: {initial_value}")
         QTimer.singleShot(5000, self._check_value)
-        print(f"Initialized PVModelRO for {self.name}")
+        print(f"[{self.name}] PVModelRO Initialized")
         return True
 
     def _cleanup(self):
@@ -388,7 +390,7 @@ class PVModelRO(BaseModel):
     def _check_value(self):
         value = self._get_value()
         self._value_changed(value)
-        QTimer.singleShot(100000, self._check_value)
+        QTimer.singleShot(10000, self._check_value)
 
     def _value_changed(self, value, **kwargs):
         """Handle value changes, with better type handling."""

--- a/src/nbs_gui/models/base.py
+++ b/src/nbs_gui/models/base.py
@@ -394,6 +394,7 @@ class PVModelRO(BaseModel):
 
     def _value_changed(self, value, **kwargs):
         """Handle value changes, with better type handling."""
+        print(f"[{self.name}] _value_changed: {value}")
         if value is None:
             if self._value is None:
                 return

--- a/src/nbs_gui/models/base.py
+++ b/src/nbs_gui/models/base.py
@@ -179,7 +179,8 @@ def formatInt(value):
     """Format an integer value."""
     try:
         return "{:d}".format(int(value))
-    except (ValueError, TypeError):
+    except (ValueError, TypeError) as e:
+        print(f"Could not convert value {value} to int: {e}")
         return str(value)  # Return as string if conversion fails
 
 
@@ -369,7 +370,8 @@ class PVModelRO(BaseModel):
                 self.value_type = str
             else:
                 self.value_type = None
-        except:
+        except Exception as e:
+            print(f"[{self.name}] Error in _initialize value_type: {e}")
             self.value_type = None
 
         self.sub_key = self.obj.subscribe(self._value_changed, run=False)

--- a/src/nbs_gui/models/base.py
+++ b/src/nbs_gui/models/base.py
@@ -373,7 +373,7 @@ class PVModelRO(BaseModel):
         except Exception as e:
             print(f"[{self.name}] Error in _initialize value_type: {e}")
             self.value_type = None
-
+        print(f"[{self.name}] value_type: {self.value_type}")
         self.sub_key = self.obj.subscribe(self._value_changed, run=False)
         initial_value = self._get_value(check_connection=False)
         self._value_changed(initial_value)
@@ -394,7 +394,7 @@ class PVModelRO(BaseModel):
         self._value_changed(value)
         QTimer.singleShot(10000, self._check_value)
 
-    def _value_changed(self, value, **kwargs):
+    def _value_changed(self, value, print_value=False, **kwargs):
         """Handle value changes, with better type handling."""
         # print(f"[{self.name}] _value_changed: {value}")
         if value is None:
@@ -410,6 +410,8 @@ class PVModelRO(BaseModel):
             if hasattr(value, "_fields"):
                 if hasattr(value, "user_readback"):
                     value = value.user_readback
+                elif hasattr(value, "readback"):
+                    value = value.readback
                 elif hasattr(value, "value"):
                     value = value.value
 
@@ -421,6 +423,7 @@ class PVModelRO(BaseModel):
                     self.value_type = int
                 else:
                     self.value_type = str
+                print(f"[{self.name}] new value_type: {self.value_type}")
 
             # Format based on type
             if self.value_type is float:
@@ -429,6 +432,9 @@ class PVModelRO(BaseModel):
                 formatted_value = formatInt(value)
             else:
                 formatted_value = str(value)
+            if print_value:
+                print(f"[{self.name}] value changed to {formatted_value}")
+
             if self._value != formatted_value:
                 self._value = formatted_value
                 self.valueChanged.emit(formatted_value)

--- a/src/nbs_gui/models/base.py
+++ b/src/nbs_gui/models/base.py
@@ -62,7 +62,7 @@ def initialize_with_retry(func, retry_intervals=None, jitter_factor=0.2):
         if qual_name in self._init_retry_timers:
             timer = self._init_retry_timers[qual_name]
             if timer.isActive():
-                print(f"Retry already scheduled for {qual_name}, " "waiting for timer")
+                # print(f"Retry already scheduled for {qual_name}, " "waiting for timer")
                 return False
 
         try:

--- a/src/nbs_gui/models/base.py
+++ b/src/nbs_gui/models/base.py
@@ -394,7 +394,7 @@ class PVModelRO(BaseModel):
 
     def _value_changed(self, value, **kwargs):
         """Handle value changes, with better type handling."""
-        print(f"[{self.name}] _value_changed: {value}")
+        # print(f"[{self.name}] _value_changed: {value}")
         if value is None:
             if self._value is None:
                 return
@@ -431,7 +431,7 @@ class PVModelRO(BaseModel):
                 self._value = formatted_value
                 self.valueChanged.emit(formatted_value)
         except Exception as e:
-            print(f"Error in _value_changed for {self.name}: {e}")
+            print(f"[{self.name}] Error in _value_changed for value {value}: {e}")
             self._value = str(value)
             self.valueChanged.emit(str(value))
 

--- a/src/nbs_gui/models/motors.py
+++ b/src/nbs_gui/models/motors.py
@@ -9,7 +9,7 @@ from ..views.switchable_motors import (
     SwitchableMotorMonitor,
     SwitchableMotorControl,
 )
-from .base import PVModel, BaseModel
+from .base import PVModel, BaseModel, requires_connection, initialize_with_retry
 
 CONNECTION_ERRORS = (
     ReadTimeoutError,
@@ -35,59 +35,95 @@ def MotorModel(name, obj, group, long_name, **kwargs):
         )
 
 
-class EPICSMotorModel(PVModel):
+class BaseMotorModel(PVModel):
     default_controller = MotorControl
     default_monitor = MotorMonitor
     movingStatusChanged = Signal(bool)
     setpointChanged = Signal(object)
 
+    @property
+    def moving(self):
+        return self._moving
+
+    @property
+    def position(self):
+        print(f"[{self.name}.position] Getting position")
+        pos = self._get_position()
+        print(f"[{self.name}.position] Got position: {pos}")
+        return pos
+
+    @property
+    def limits(self):
+        return self._get_limits()
+
+    @requires_connection
+    def stop(self):
+        self.obj.stop()
+
+    @requires_connection
+    def _get_limits(self):
+        if hasattr(self.obj, "limits"):
+            return self.obj.limits
+        else:
+            return (None, None)
+
+
+class EPICSMotorModel(BaseMotorModel):
+
     def __init__(self, name, obj, group, long_name, **kwargs):
         super().__init__(name, obj, group, long_name, **kwargs)
+        self.units = None
+        self._obj_setpoint = None
+        self._setpoint = None
+        self._position = None
+        self._moving = False
+        self.checkValueTimer = QTimer(self)
+        self._initialize()
 
-        print(f"Initializing EPICSMotorModel for {name}")
+    @initialize_with_retry
+    def _initialize(self):
+        if not super()._initialize():
+            return False
+
+        print(f"Initializing EPICSMotorModel for {self.name}")
         self.obj.motor_is_moving.subscribe(self._update_moving_status)
 
-        print("Setting up setpoint for {name}")
+        print(f"Setting up setpoint for {self.name}")
         if "user_setpoint" in self.obj.__dir__():
-            print(f"Using user_setpoint for {name}._obj_setpoint")
+            print(f"Using user_setpoint for {self.name}._obj_setpoint")
             self._obj_setpoint = self.obj.user_setpoint
         elif "setpoint" in self.obj.__dir__():
-            print(f"Using setpoint for {name}._obj_setpoint")
+            print(f"Using setpoint for {self.name}._obj_setpoint")
             self._obj_setpoint = self.obj.setpoint
         else:
-            print(f"Using obj for {name}._obj_setpoint")
+            print(f"Using obj for {self.name}._obj_setpoint")
             self._obj_setpoint = self.obj
 
         if hasattr(self._obj_setpoint, "metadata"):
             self.units = self._obj_setpoint.metadata.get("units", None)
         else:
             self.units = None
-        print(f"{name} has units {self.units}")
+        print(f"{self.name} has units {self.units}")
 
         # Initialize state
-        self._setpoint = 0
-        self._moving = False
 
         # Set up timer for checking setpoint
-        self.checkValueTimer = QTimer(self)
-        self.checkValueTimer.setInterval(500)
+
+        # Get initial position -- not initialized yet, so don't check connection!
+        self._position = self._get_position(check_connection=False)
+        print(f"Got initial position for {self.name}: {self._position}")
+        self._setpoint = self._position
+        self.setpointChanged.emit(self._setpoint)
+
+        self.checkValueTimer.setInterval(1000)
         self.checkValueTimer.timeout.connect(self._check_value)
         self.checkValueTimer.start()
 
-        try:
-            initial_pos = self.position
-            print(f"Got initial position for {name}: {initial_pos}")
-            self._setpoint = initial_pos
-        except CONNECTION_ERRORS as e:
-            print(f"Error getting initial position for {name}: {e}, using 0")
-        print(f"Initialized EPICSMotorModel for {name}")
+        return True
 
     def _update_moving_status(self, value, **kwargs):
-        try:
-            self.movingStatusChanged.emit(value)
-            self._handle_reconnection()
-        except CONNECTION_ERRORS as e:
-            self._handle_connection_error(e, "updating moving status")
+        self._moving = value
+        self.movingStatusChanged.emit(value)
 
     def _check_value(self):
         """
@@ -100,14 +136,18 @@ class EPICSMotorModel(PVModel):
             self._value_changed(value)
 
             # Check setpoint
-            new_sp = self._obj_setpoint.get(connection_timeout=0.2)
-            if new_sp != self._setpoint:
+            new_sp = self._get_setpoint()
+            if new_sp is None:
+                self._setpoint = None
+                self.setpointChanged.emit(self._setpoint)
+            elif new_sp != self._setpoint:
                 self._setpoint = new_sp
                 self.setpointChanged.emit(self._setpoint)
-
-            self._handle_reconnection()
-            self.checkValueTimer.setInterval(500)
-        except CONNECTION_ERRORS + (TypeError, ValueError) as e:
+            if value is not None:
+                self.checkValueTimer.setInterval(1000)
+            else:
+                self.checkValueTimer.setInterval(8000)
+        except (TypeError, ValueError) as e:
             self._handle_connection_error(e, "checking value")
             self.checkValueTimer.setInterval(8000)
 
@@ -115,68 +155,47 @@ class EPICSMotorModel(PVModel):
     def setpoint(self):
         return self._setpoint
 
-    @property
-    def position(self):
-        try:
-            pos = self.obj.position
-            self._handle_reconnection()
-            return pos
-        except CONNECTION_ERRORS + (TypeError, ValueError) as e:
-            self._handle_connection_error(e, "getting position")
-            return 0
+    @requires_connection
+    def _get_position(self):
+        return self.obj.position
 
-    @property
-    def limits(self):
-        try:
-            if hasattr(self.obj, "limits"):
-                return self.obj.limits
-            else:
-                return (None, None)
-        except CONNECTION_ERRORS as e:
-            self._handle_connection_error(e, "getting limits")
-            return (None, None)
+    @requires_connection
+    def _get_setpoint(self):
+        return self._obj_setpoint.get(connection_timeout=0.2)
 
+    @requires_connection
     def set(self, value):
+        print(f"[{self.name}] Requesting move to {value}")
         try:
-            print(f"[{self.name}] Requesting move to {value}")
             self._obj_setpoint.set(value).wait()
-            self._handle_reconnection()
-        except CONNECTION_ERRORS + (TypeError, ValueError) as e:
-            self._handle_connection_error(e, "setting position")
-
-    def stop(self):
-        try:
-            self.obj.stop()
-            self._handle_reconnection()
-        except CONNECTION_ERRORS as e:
-            self._handle_connection_error(e, "stopping motor")
+        except (ValueError, TypeError) as e:
+            msg = f"Value {value} cannot be set: {e}"
+            raise ValueError(msg) from e
+        return value
 
 
-class PVPositionerModel(PVModel):
-    default_controller = MotorControl
-    default_monitor = MotorMonitor
-    movingStatusChanged = Signal(bool)
-    setpointChanged = Signal(object)
-
-    @property
-    def position(self):
-        """Get the current position of the motor."""
-        try:
-            pos = self._obj_readback.get(timeout=0.2)
-            self._handle_reconnection()
-            return pos
-        except Exception as e:
-            self._handle_connection_error(e, "getting position")
-            return 0
-
-    @property
-    def setpoint(self):
-        """Get the current setpoint."""
-        return self._setpoint
+class PVPositionerModel(BaseMotorModel):
 
     def __init__(self, name, obj, group, long_name, **kwargs):
         print(f"Initializing PVPositionerModel for {name}")
         super().__init__(name, obj, group, long_name, **kwargs)
+        self._setpoint = None
+        self._target = None
+        self._moving = False
+        self._obj_setpoint = None
+        self._obj_readback = None
+        self.units = None
+        self.checkSPTimer = QTimer(self)
+        self.checkMovingTimer = QTimer(self)
+        self.checkValueTimer = QTimer(self)
+
+        self._initialize()
+
+    @initialize_with_retry
+    def _initialize(self):
+        if not super()._initialize():
+            return False
+
         if hasattr(self.obj, "user_setpoint"):
             self._obj_setpoint = self.obj.user_setpoint
         elif hasattr(self.obj, "setpoint"):
@@ -195,52 +214,64 @@ class PVPositionerModel(PVModel):
             self.units = self._obj_setpoint.metadata.get("units", None)
         else:
             self.units = None
-        print(f"{name} has units {self.units}")
+        print(f"{self.name} has units {self.units}")
 
         # Initialize state
-        self._setpoint = 0
-        self._target = 0
-        self._moving = False
 
         # Set up timers
-        self.checkSPTimer = QTimer(self)
         self.checkSPTimer.setInterval(1000)
         self.checkSPTimer.timeout.connect(self._check_setpoint)
-        self.checkMovingTimer = QTimer(self)
+
         self.checkMovingTimer.setInterval(500)
         self.checkMovingTimer.timeout.connect(self._check_moving)
 
         # Start the timers
+
+        self.checkValueTimer.setInterval(500)
+        self.checkValueTimer.timeout.connect(self._check_value)
+
         self.checkSPTimer.start()
         self.checkMovingTimer.start()
-
+        self.checkValueTimer.start()
         # Try to get initial position
         try:
-            initial_pos = self.position
-            print(f"Got initial position for {name}: {initial_pos}")
+            initial_pos = self._get_position(check_connection=False)
+            print(f"Got initial position for {self.name}: {initial_pos}")
+
             self._setpoint = initial_pos
             self._target = initial_pos
+            self.setpointChanged.emit(self._setpoint)
+
         except Exception as e:
-            print(f"Error getting initial position for {name}: {e}, using 0")
-        print(f"Initialized PVPositionerModel for {name}")
+            print(f"Error getting initial position for {self.name}: {e}, using 0")
+        print(f"Initialized PVPositionerModel for {self.name}")
+        return True
+
+    @requires_connection
+    def _get_position(self):
+        try:
+            return self._obj_readback.get(timeout=0.2)
+        except Exception as e:
+            print(f"Error getting position for {self.name}: {e}, using None")
+            return None
+
+    @property
+    def setpoint(self):
+        """Get the current setpoint."""
+        return self._setpoint
 
     def _check_value(self):
         """
         Override base class to handle readback value checking for positioners.
         For positioners, we want the actual position value.
         """
-        # print(f"[{self.name}] Done getting value")
-        try:
-            # Get the current position directly
-            value = self.position
-            self._value_changed(value)
-            self._handle_reconnection()
-            QTimer.singleShot(100000, self._check_value)
-        except CONNECTION_ERRORS + (TypeError, ValueError, AttributeError) as e:
-            self._handle_connection_error(e, "checking value")
-            QTimer.singleShot(100000, self._check_value)
+        value = self.position
+        self._value_changed(value)
 
-        # print(f"[{self.name}] Done getting value")
+        if value is not None:
+            self.checkValueTimer.setInterval(1000)
+        else:
+            self.checkValueTimer.setInterval(8000)
 
     def _check_setpoint(self):
         """
@@ -251,7 +282,7 @@ class PVPositionerModel(PVModel):
         try:
             if not all(
                 isinstance(x, (int, float))
-                for x in [self._setpoint, self._target, self.position]
+                for x in [self.setpoint, self._target, self.position]
             ):
                 return
         except (TypeError, ValueError):
@@ -262,7 +293,7 @@ class PVPositionerModel(PVModel):
                 # During motion, show where we're trying to go
                 if self._setpoint != self._target:
                     self._setpoint = self._target
-                    self.setpointChanged.emit(self._setpoint)
+                    self.setpointChanged.emit(self.setpoint)
             else:
                 # After motion completes, update to actual position if different
                 achieved_pos = float(self.position)
@@ -274,65 +305,82 @@ class PVPositionerModel(PVModel):
                     # )
                     self._setpoint = achieved_pos
                     self._target = achieved_pos
-                    self.setpointChanged.emit(self._setpoint)
+                    self.setpointChanged.emit(self.setpoint)
 
-            self._handle_reconnection()
-            self.checkSPTimer.setInterval(1000)
-        except CONNECTION_ERRORS + (TypeError, ValueError, AttributeError) as e:
+            self.checkSPTimer.setInterval(2000)
+        except (TypeError, ValueError, AttributeError) as e:
             self._handle_connection_error(e, "checking setpoint")
-            self.checkSPTimer.setInterval(60000)
+            self.checkSPTimer.setInterval(10000)
         # print(f"[{self.name}] done getting sp")
 
-    @property
-    def limits(self):
-        try:
-            if hasattr(self.obj, "limits"):
-                return self.obj.limits
-            else:
-                return (None, None)
-        except CONNECTION_ERRORS as e:
-            self._handle_connection_error(e, "getting limits")
-            return (None, None)
-
+    @requires_connection
     def _check_moving(self):
+        moving = self.obj.moving
+        return moving
+
+    def check_moving(self):
         # print(f"[{self.name}] getting move status")
-        try:
-            moving = self.obj.moving
-            self._handle_reconnection()
+        moving = self._check_moving()
+        if moving is not None:
             self.checkMovingTimer.setInterval(1000)
-        except CONNECTION_ERRORS as e:
-            self._handle_connection_error(e, "checking moving status")
-            self.checkMovingTimer.setInterval(60000)
-            return
+        else:
+            self.checkMovingTimer.setInterval(10000)
 
         if moving != self._moving:
             self.movingStatusChanged.emit(moving)
             self._moving = moving
         # print(f"[{self.name}] Done getting move status")
 
+    @requires_connection
     def set(self, value):
         """
         Request a move to a new position.
         Update the target and setpoint immediately to show where we're going.
         """
-        try:
-            print(f"[{self.name}] Requesting move to {value}")
-            self._target = value
-            self._setpoint = value
-            self.setpointChanged.emit(self._setpoint)
-            self.obj.set(value)
-            print(f"[{self.name}] After set to {value}")
-            self._handle_reconnection()
-        except CONNECTION_ERRORS as e:
-            self._handle_connection_error(e, "setting position")
+
+        print(f"[{self.name}] Requesting move to {value}")
+        self._target = value
+        self._setpoint = value
+        self.setpointChanged.emit(self._setpoint)
+        self.obj.set(value)
         print(f"[{self.name}] Done requesting move")
 
-    def stop(self):
+
+class PseudoPositionerModel(PVPositionerModel):
+
+    def _check_connection(self, retry_on_failure=True):
+        """
+        Check connection and handle reconnection attempts.
+        All connection checking and reconnection logic lives here.
+
+        For pseudoaxes we need to check the connection of the parent object
+        """
+
         try:
-            self.obj.stop()
-            self._handle_reconnection()
-        except CONNECTION_ERRORS as e:
-            self._handle_connection_error(e, "stopping motor")
+            if "wait_for_connection" in dir(self.obj.parent):
+                print(f"[{self.name}._check_connection] Waiting for connection")
+                self.obj.parent.wait_for_connection(timeout=0.2, connection_timeout=0.2)
+                connected = True
+            else:
+                print(f"[{self.name}._check_connection] Getting value")
+                self.obj.get(timeout=0.2, connection_timeout=0.2)
+                connected = True
+        except Exception as e:
+            print(f"[{self.name}._check_connection] Error: {e}")
+            connected = False
+        print(f"[{self.name}._check_connection] Connected: {connected}")
+        # Update connection state if changed
+        if connected != self._connected:
+            self._connected = connected
+            self.connectionStatusChanged.emit(connected)
+
+            # If we're now connected, try initialization
+            if not connected and retry_on_failure:
+                if not self._reconnection_timer.isActive():
+                    print(f"Starting reconnection timer for {self.name}")
+                    self._reconnection_timer.start(60000)
+
+        return connected
 
 
 class MultiMotorModel(BaseModel):
@@ -459,7 +507,7 @@ class PseudoPositionerModel(MultiMotorModel):
 
         # Create models for pseudo motors
         self.pseudo_motors = [
-            PVPositionerModel(
+            PseudoPositionerModel(
                 name=ps_axis.name,
                 obj=ps_axis,
                 group=group,

--- a/src/nbs_gui/models/motors.py
+++ b/src/nbs_gui/models/motors.py
@@ -88,15 +88,15 @@ class EPICSMotorModel(BaseMotorModel):
         print(f"Initializing EPICSMotorModel for {self.name}")
         self.obj.motor_is_moving.subscribe(self._update_moving_status)
 
-        print(f"Setting up setpoint for {self.name}")
+        # print(f"Setting up setpoint for {self.name}")
         if "user_setpoint" in self.obj.__dir__():
-            print(f"Using user_setpoint for {self.name}._obj_setpoint")
+            # print(f"Using user_setpoint for {self.name}._obj_setpoint")
             self._obj_setpoint = self.obj.user_setpoint
         elif "setpoint" in self.obj.__dir__():
-            print(f"Using setpoint for {self.name}._obj_setpoint")
+            # print(f"Using setpoint for {self.name}._obj_setpoint")
             self._obj_setpoint = self.obj.setpoint
         else:
-            print(f"Using obj for {self.name}._obj_setpoint")
+            # print(f"Using obj for {self.name}._obj_setpoint")
             self._obj_setpoint = self.obj
 
         if hasattr(self._obj_setpoint, "metadata"):

--- a/src/nbs_gui/models/motors.py
+++ b/src/nbs_gui/models/motors.py
@@ -47,9 +47,9 @@ class BaseMotorModel(PVModel):
 
     @property
     def position(self):
-        print(f"[{self.name}.position] Getting position")
+        # print(f"[{self.name}.position] Getting position")
         pos = self._get_position()
-        print(f"[{self.name}.position] Got position: {pos}")
+        # print(f"[{self.name}.position] Got position: {pos}")
         return pos
 
     @property
@@ -278,7 +278,7 @@ class PVPositionerModel(BaseMotorModel):
         For pseudo-motors, we track both the target (where we want to go)
         and the setpoint (where we actually end up).
         """
-        print(f"Checking setpoint for {self.name}")
+        # print(f"[{self.name}._check_setpoint] Checking setpoint")
         try:
             if not all(
                 isinstance(x, (int, float))

--- a/src/nbs_gui/models/motors.py
+++ b/src/nbs_gui/models/motors.py
@@ -346,7 +346,7 @@ class PVPositionerModel(BaseMotorModel):
         print(f"[{self.name}] Done requesting move")
 
 
-class PseudoPositionerModel(PVPositionerModel):
+class PseudoSingleModel(PVPositionerModel):
 
     def _check_connection(self, retry_on_failure=True):
         """
@@ -359,7 +359,7 @@ class PseudoPositionerModel(PVPositionerModel):
         try:
             if "wait_for_connection" in dir(self.obj.parent):
                 print(f"[{self.name}._check_connection] Waiting for connection")
-                self.obj.parent.wait_for_connection(timeout=0.2, connection_timeout=0.2)
+                self.obj.parent.wait_for_connection(timeout=0.2)
                 connected = True
             else:
                 print(f"[{self.name}._check_connection] Getting value")
@@ -495,6 +495,8 @@ class PseudoPositionerModel(MultiMotorModel):
         )
 
         # Create models for real motors
+        print(f"[{self.name}] Intializing PseudoPositionerModel")
+        print(f"[{self.name}] Creating real motors")
         self.real_motors = [
             MotorModel(
                 name=real_axis.name,
@@ -504,10 +506,11 @@ class PseudoPositionerModel(MultiMotorModel):
             )
             for real_axis in obj.real_positioners
         ]
-
+        print(f"[{self.name}] Created {len(self.real_motors)} real motors")
         # Create models for pseudo motors
+        print(f"[{self.name}] Creating pseudo motors")
         self.pseudo_motors = [
-            PseudoPositionerModel(
+            PseudoSingleModel(
                 name=ps_axis.name,
                 obj=ps_axis,
                 group=group,
@@ -515,3 +518,4 @@ class PseudoPositionerModel(MultiMotorModel):
             )
             for ps_axis in obj.pseudo_positioners
         ]
+        print(f"[{self.name}] Created {len(self.pseudo_motors)} pseudo motors")

--- a/src/nbs_gui/models/motors.py
+++ b/src/nbs_gui/models/motors.py
@@ -134,7 +134,7 @@ class EPICSMotorModel(BaseMotorModel):
             # Get current position
             value = self.position
             self._value_changed(value)
-
+            # print(f"[{self.name}] check_value: {value}")
             # Check setpoint
             new_sp = self._get_setpoint()
             if new_sp is None:
@@ -145,11 +145,14 @@ class EPICSMotorModel(BaseMotorModel):
                 self.setpointChanged.emit(self._setpoint)
             if value is not None:
                 self.checkValueTimer.setInterval(1000)
+                # self.checkValueTimer.start()
             else:
                 self.checkValueTimer.setInterval(8000)
+                # self.checkValueTimer.start()
         except (TypeError, ValueError) as e:
             self._handle_connection_error(e, "checking value")
             self.checkValueTimer.setInterval(8000)
+            # self.checkValueTimer.start()
 
     @property
     def setpoint(self):
@@ -267,11 +270,13 @@ class PVPositionerModel(BaseMotorModel):
         """
         value = self.position
         self._value_changed(value)
-
+        # print(f"[{self.name}] check_value: {value}")
         if value is not None:
             self.checkValueTimer.setInterval(1000)
+            # self.checkValueTimer.start()
         else:
             self.checkValueTimer.setInterval(8000)
+            # self.checkValueTimer.start()
 
     def _check_setpoint(self):
         """

--- a/src/nbs_gui/views/enums.py
+++ b/src/nbs_gui/views/enums.py
@@ -64,10 +64,16 @@ class EnumControl(QWidget):
         val : str
             Current value to display
         """
-        self.value.setText(val)
-        index = self.combo.findText(val)
-        if index >= 0:
-            self.combo.setCurrentIndex(index)
+        if val is None:
+            val = "Disconnected"
+            self.value.setText(val)
+            self.combo.setCurrentIndex(-1)
+            return
+        else:
+            self.value.setText(val)
+            index = self.combo.findText(val)
+            if index >= 0:
+                self.combo.setCurrentIndex(index)
 
     def updateCombo(self, enum_strs):
         """Update the combo box items.
@@ -138,4 +144,6 @@ class EnumMonitor(QWidget):
         val : str
             Value to display
         """
+        if val is None:
+            val = "Disconnected"
         self.value.setText(str(val))

--- a/src/nbs_gui/views/monitors.py
+++ b/src/nbs_gui/views/monitors.py
@@ -106,6 +106,8 @@ class PVControl(QWidget):
         val : str
             Formatted value to display
         """
+        if val is None:
+            val = "Disconnected"
         self.value.setText(f"{val} {self.units}")
 
 
@@ -158,6 +160,8 @@ class PVMonitor(QWidget):
         val : str
             Formatted value to display
         """
+        if val is None:
+            val = "Disconnected"
         self.value.setText(f"{val} {self.units}")
 
 

--- a/src/nbs_gui/views/monitors.py
+++ b/src/nbs_gui/views/monitors.py
@@ -162,6 +162,7 @@ class PVMonitor(QWidget):
         """
         if val is None:
             val = "Disconnected"
+        print(f"[{self.model.name}] PVMonitor setText: {val}")
         self.value.setText(f"{val} {self.units}")
 
 

--- a/src/nbs_gui/views/monitors.py
+++ b/src/nbs_gui/views/monitors.py
@@ -150,6 +150,7 @@ class PVMonitor(QWidget):
             box.setAlignment(Qt.AlignVCenter)
 
         self.model.valueChanged.connect(self.setText)
+        print(f"[{self.model.name}] PVMonitor initial setText: {self.model.value}")
         self.setText(self.model.value)
         self.setLayout(box)
 

--- a/src/nbs_gui/views/monitors.py
+++ b/src/nbs_gui/views/monitors.py
@@ -82,6 +82,8 @@ class PVControl(QWidget):
             box.setAlignment(Qt.AlignVCenter)
 
         self.model.valueChanged.connect(self.setText)
+        print(f"[{self.model.name}] PVControl initial setText: {self.model.value}")
+        self.setText(self.model.value)
         self.setLayout(box)
 
     def enter_value(self):

--- a/src/nbs_gui/views/monitors.py
+++ b/src/nbs_gui/views/monitors.py
@@ -150,6 +150,7 @@ class PVMonitor(QWidget):
             box.setAlignment(Qt.AlignVCenter)
 
         self.model.valueChanged.connect(self.setText)
+        self.setText(self.model.value)
         self.setLayout(box)
 
     def setText(self, val):
@@ -162,7 +163,6 @@ class PVMonitor(QWidget):
         """
         if val is None:
             val = "Disconnected"
-        print(f"[{self.model.name}] PVMonitor setText: {val}")
         self.value.setText(f"{val} {self.units}")
 
 

--- a/src/nbs_gui/views/motor.py
+++ b/src/nbs_gui/views/motor.py
@@ -64,6 +64,7 @@ class MotorMonitor(QWidget):
     def update_position(self, value):
         if value is None:
             value = "Disconnected"
+        # print(f"[MotorMonitor {self.model.label}] update_position: {value}")
         self.position.setText(f"{value} {self.units}")
 
     @Slot(bool)
@@ -152,7 +153,7 @@ class MotorControl(MotorMonitor):
             self.lineEdit.setText("Disconnected")
             self.indicator.setColor("red")
         else:
-            self.update_position(self.model.position)
+            self.update_position(self.model.value)
             self.update_sp(self.model.setpoint)
             self.update_indicator(self.model.moving)
 

--- a/src/nbs_gui/views/motor.py
+++ b/src/nbs_gui/views/motor.py
@@ -121,7 +121,7 @@ class MotorControl(MotorMonitor):
         self.stopButton = QPushButton("Stop!")
         self.stopButton.setFixedWidth(60)
         self.stopButton.setFixedHeight(20)
-        self.stopButton.clicked.connect(self.model.stop)
+        self.stopButton.clicked.connect(lambda x: self.model.stop())
 
         # Add remaining widgets in sequence
         self.box.addWidget(self.gobutton)

--- a/src/nbs_gui/views/motor.py
+++ b/src/nbs_gui/views/motor.py
@@ -300,15 +300,15 @@ class MotorProgressBar(QWidget):
 
     def update_range(self, setpoint):
         """Update the progress bar range with new setpoint."""
-        print(f"[{self.model.label}.update_range] Updating range")
+        # print(f"[{self.model.label}.update_range] Updating range")
 
         if setpoint is None or self.model.position is None:
-            print(f"[{self.model.label}.update_range] Progress bar disabled")
+            # print(f"[{self.model.label}.update_range] Progress bar disabled")
             self.progress_bar.setEnabled(False)
             self.label.setText(f"{self.model.label}: DISCONNECTED")
             return
 
-        print(f"[{self.model.label}.update_range] Progress bar enabled")
+        # print(f"[{self.model.label}.update_range] Progress bar enabled")
         self.progress_bar.setEnabled(True)
         current_value = float(self.model.position)
         setpoint = float(setpoint)
@@ -318,14 +318,14 @@ class MotorProgressBar(QWidget):
 
     def update_progress(self, value):
         """Update progress bar with new value."""
-        print(
-            f"[{self.model.label}.update_progress] Updating progress with value {value}"
-        )
+        # print(
+        #     f"[{self.model.label}.update_progress] Updating progress with value {value}"
+        # )
         if value is None or self.model.setpoint is None or value == "None":
             self.progress_bar.setEnabled(False)
             self.label.setText(f"{self.model.label}: Disconnected")
             return
-        print(f"[{self.model.label}.update_progress] Progress bar enabled")
+        # print(f"[{self.model.label}.update_progress] Progress bar enabled")
         self.progress_bar.setEnabled(True)
         try:
             value = float(value)

--- a/src/nbs_gui/views/motor.py
+++ b/src/nbs_gui/views/motor.py
@@ -163,8 +163,9 @@ class MotorControl(MotorMonitor):
         bool
             True if within limits, False otherwise
         """
-        if hasattr(self.model.obj, "limits"):
-            low, high = self.model.obj.limits
+        if hasattr(self.model, "limits"):
+            low, high = self.model.limits
+
             if low == high:
                 # If the limits are the same, they are probably not really set
                 return True
@@ -388,10 +389,14 @@ class DynamicMotorBox(QGroupBox):
         self.layout.addWidget(self.scroll_area)
 
         self.motor_progress_widgets = []
+        print("Models: ", models)
         if isinstance(models, dict):
             models = list(models.values())
         for m in models:
-            # print(f"Adding motor widget for model: {m.label}")
+            if m is None:
+                print("Model is None")
+                continue
+            print(f"Adding motor widget for model: {m.label}")
             if m.default_monitor == MotorMonitor:
                 widget = DynamicMotorBar(m, parent_model)
                 widget.setVisible(False)

--- a/src/nbs_gui/views/motor.py
+++ b/src/nbs_gui/views/motor.py
@@ -21,7 +21,7 @@ from ..widgets.utils import SquareByteIndicator
 class MotorMonitor(QWidget):
     def __init__(self, model, parent_model, orientation="h", *args, **kwargs):
         super().__init__(*args, **kwargs)
-        print(f"Initializing MotorMonitor for model: {model.label}")
+        print(f"[{model.label}] Initializing MotorMonitor")
         self.model = model
         if orientation == "h":
             self.box = QHBoxLayout()
@@ -46,7 +46,7 @@ class MotorMonitor(QWidget):
         self.position.setFixedWidth(100)
         self.position.setFixedHeight(20)
         self.position.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
-        print(self.model.label, self.model.value)
+        print(f"[{self.model.label}] Position: {self.model.value}")
         self.box.addWidget(self.position)
 
         # Status indicator
@@ -72,8 +72,8 @@ class MotorMonitor(QWidget):
 
 class MotorControl(MotorMonitor):
     def __init__(self, model, *args, **kwargs):
+        print(f"[{model.label}] Initializing MotorControl")
         super().__init__(model, *args, **kwargs)
-        print(f"Initializing MotorControl for model: {model.label}")
         # Fixed-width input field
         self.lineEdit = QLineEdit()
         self.lineEdit.setFixedWidth(100)

--- a/src/nbs_gui/views/views.py
+++ b/src/nbs_gui/views/views.py
@@ -241,6 +241,7 @@ class AutoControlCombo(QWidget):
 
         # Set size policy for widgetStack
         widgetStack.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Minimum)
+        print(f"AutoControlCombo {title} initialized")
 
 
 class DynamicControlWidget(QStackedWidget):

--- a/src/nbs_gui/widgets/simpleConsoleMonitor.py
+++ b/src/nbs_gui/widgets/simpleConsoleMonitor.py
@@ -37,7 +37,7 @@ class PushButtonMinimumWidth(QPushButton):
 class QtReConsoleMonitor(QWidget):
     def __init__(self, model, parent=None):
         super().__init__(parent)
-        # self.setAttribute(Qt.WA_DeleteOnClose)
+        self.setAttribute(Qt.WA_DeleteOnClose)
         print("New QtReConsoleMonitor with QPlainTextEdit")
         self._max_lines = 1000
 
@@ -93,6 +93,10 @@ class QtReConsoleMonitor(QWidget):
         self._start_thread()
         self._start_timer()
         self._stop = False
+
+    def __del__(self):
+        self.model.stop_console_output_monitoring()
+        self._stop = True
 
     def _process_new_console_output(self, result):
         """

--- a/src/nbs_gui/window.py
+++ b/src/nbs_gui/window.py
@@ -67,6 +67,7 @@ class MainWindow(Window):
         """Update the main widget with a new widget and header"""
         config = SETTINGS.gui_config
         header_entrypoint = config.get("gui", {}).get("header", "nbs-gui-header")
+        print(f"Loading header from {header_entrypoint}")
         HeaderClass = self.load_header_from_entrypoint(header_entrypoint)
 
         # Clear existing widgets


### PR DESCRIPTION
This branch has now been tested on HAXPES. Things expanded a bit, the main improvement is a total re-write of the GUI model initialization process, to handle disconnected PVs. Improvements:

- Models now have an initialize hierarchically, waiting for success of each parent class
- Models retry initialization if signals are not connected
- Methods can be marked "connection required", and if signals are not connected, they will return "None" quickly to avoid blocking the GUI
- Some views now listen for connect/disconnect.

It is now possible to start the GUI while all PVs are disconnected.

Other misc improvements:

- Views updated to grab values on startup to deal with new delayed initialization
- Stop button fixed for motors
- SimpleConsoleMonitor fixed to avoid previous hang on GUI exit (fixes #1 )