### PR TITLE
Bl customization

### DIFF
--- a/src/nbs_gui/plans/scanModifier.py
+++ b/src/nbs_gui/plans/scanModifier.py
@@ -6,6 +6,7 @@ from qtpy.QtWidgets import (
 
 from qtpy.QtCore import Signal, Qt
 from .planParam import ParamGroup, SpinBoxParam, LineEditParam, TextEditParam
+from nbs_gui.settings import SETTINGS
 
 
 class ScanModifierParam(ParamGroup):
@@ -97,19 +98,23 @@ class BeamlineModifierParam(ParamGroup):
     def __init__(self, model, parent=None):
         super().__init__(parent, "Beamline Setup")
 
-        self.add_param(LineEditParam("eslit", float, "Exit Slit"))
-        self.add_param(
-            LineEditParam(
-                "polarization",
-                float,
-                "Polarization",
-                "EPU Polarization to set at plan start",
+        config = SETTINGS.beamline_config.get("configuration", {})
+        if config.get("has_slits", False):
+            self.add_param(LineEditParam("eslit", float, "Exit Slit"))
+        if config.get("has_polarization", False):
+            self.add_param(
+                LineEditParam(
+                    "polarization",
+                    float,
+                    "Polarization",
+                    "EPU Polarization to set at plan start",
+                )
             )
-        )
+        if config.get("has_motorized_eref", False):
+            self.add_param(ReferenceComboParam(model))
         self.add_param(
-            LineEditParam("energy", float, "Energy", "Energy to set a plan start")
+            LineEditParam("energy", float, "Energy", "Energy to set at plan start")
         )
-        self.add_param(ReferenceComboParam(model))
 
     def check_ready(self):
         # All parameters optional, so return True

--- a/src/nbs_gui/views/gatevalve.py
+++ b/src/nbs_gui/views/gatevalve.py
@@ -39,9 +39,9 @@ class GVControl(GVMonitor):
         super().__init__(model, *args, **kwargs)
         print(f"Initializing GVControl for model: {model.label}")
         self.opn = QPushButton("Open")
-        self.opn.clicked.connect(self.model.open)
+        self.opn.clicked.connect(lambda x: self.model.open())
         self.close = QPushButton("Close")
-        self.close.clicked.connect(self.model.close)
+        self.close.clicked.connect(lambda x: self.model.close())
         self.vbox.insertWidget(1, self.opn)
         self.vbox.insertWidget(3, self.close)
 


### PR DESCRIPTION
Adding customization of plan widgets via the existing beamline.toml file. Options in that file relating to polarization, exit slit, etc, will be used to remove unnecessary options from beamline plan widget.