### PR TITLE
Fixed instantiation issue with class hierarchies

### DIFF
--- a/src/nbs_gui/models/motors.py
+++ b/src/nbs_gui/models/motors.py
@@ -78,7 +78,7 @@ class EPICSMotorModel(BaseMotorModel):
         self._position = None
         self._moving = False
         self.checkValueTimer = QTimer(self)
-        self._initialize()
+        EPICSMotorModel._initialize(self)
 
     @initialize_with_retry
     def _initialize(self):
@@ -180,7 +180,7 @@ class EPICSMotorModel(BaseMotorModel):
 class PVPositionerModel(BaseMotorModel):
 
     def __init__(self, name, obj, group, long_name, **kwargs):
-        print(f"Initializing PVPositionerModel for {name}")
+        print(f"[{name}.__init__] Initializing PVPositionerModel")
         super().__init__(name, obj, group, long_name, **kwargs)
         self._setpoint = None
         self._target = None
@@ -191,11 +191,12 @@ class PVPositionerModel(BaseMotorModel):
         self.checkSPTimer = QTimer(self)
         self.checkMovingTimer = QTimer(self)
         self.checkValueTimer = QTimer(self)
-
-        self._initialize()
+        print(f"[{name}.__init__] about to call _initialize")
+        PVPositionerModel._initialize(self)
 
     @initialize_with_retry
     def _initialize(self):
+        print(f"[{self.name}._initialize] Initializing PVPositionerModel")
         if not super()._initialize():
             return False
 

--- a/src/nbs_gui/views/motor_tuple.py
+++ b/src/nbs_gui/views/motor_tuple.py
@@ -1,10 +1,39 @@
-from .switchable_motors import SwitchableMotorMonitor, SwitchableMotorControl
+from qtpy.QtWidgets import QVBoxLayout, QGroupBox, QWidget, QHBoxLayout
+from .views import AutoControl, AutoMonitor
 
 
-class MotorTupleMonitor(SwitchableMotorMonitor):
+class MotorTupleBox(QWidget):
+    """
+    Base class for a simple motor tuple view.
+
+    This is a simple widget that displays motors in a single group box,
+    without the complexity of switchable views.
+    """
+
+    def __init__(self, model, parent_model, title=None, orientation=None, **kwargs):
+        super().__init__(**kwargs)
+        self.model = model
+        self.parent_model = parent_model
+        base_title = title if title is not None else model.label
+
+        # Create main layout
+        self.layout = QVBoxLayout()
+        self.layout.setContentsMargins(0, 0, 0, 0)
+        self.setLayout(self.layout)
+
+        # Create single group box for motors
+        self.motors_box = QGroupBox(base_title)
+        self.motors_layout = QVBoxLayout()
+        self.motors_box.setLayout(self.motors_layout)
+
+        # Add box to layout
+        self.layout.addWidget(self.motors_box)
+
+
+class MotorTupleMonitor(MotorTupleBox):
     """
     Monitor widget for a tuple of motors.
-    Shows real motors with option to hide them.
+    Shows all motors in a simple, compact layout.
 
     Parameters
     ----------
@@ -12,24 +41,22 @@ class MotorTupleMonitor(SwitchableMotorMonitor):
         The model representing the motor tuple
     parent_model : object
         Parent model for the widget
+    title : str, optional
+        Title for the group box
     """
 
-    def __init__(self, model, parent_model, *args, **kwargs):
-        super().__init__(
-            title=model.label,
-            model=model,
-            parent_model=parent_model,
-            pseudo_title="Motors",  # Main view title
-            real_title="All Motors",  # Detailed view title
-            *args,
-            **kwargs,
-        )
+    def __init__(self, model, parent_model, title=None, **kwargs):
+        super().__init__(model, parent_model, title=title, **kwargs)
+
+        # Add motor monitors
+        for motor in model.real_motors:
+            self.motors_layout.addWidget(AutoMonitor(motor, parent_model))
 
 
-class MotorTupleControl(SwitchableMotorControl):
+class MotorTupleControl(MotorTupleBox):
     """
     Control widget for a tuple of motors.
-    Shows real motors with option to hide them.
+    Shows all motors in a simple, compact layout.
 
     Parameters
     ----------
@@ -37,15 +64,13 @@ class MotorTupleControl(SwitchableMotorControl):
         The model representing the motor tuple
     parent_model : object
         Parent model for the widget
+    title : str, optional
+        Title for the group box
     """
 
-    def __init__(self, model, parent_model, *args, **kwargs):
-        super().__init__(
-            title=model.label,
-            model=model,
-            parent_model=parent_model,
-            pseudo_title="Motors",  # Main view title
-            real_title="All Motors",  # Detailed view title
-            *args,
-            **kwargs,
-        )
+    def __init__(self, model, parent_model, title=None, **kwargs):
+        super().__init__(model, parent_model, title=title, **kwargs)
+
+        # Add motor controls
+        for motor in model.real_motors:
+            self.motors_layout.addWidget(AutoControl(motor, parent_model))

--- a/src/nbs_gui/views/switchable_motors.py
+++ b/src/nbs_gui/views/switchable_motors.py
@@ -1,6 +1,5 @@
 from qtpy.QtWidgets import QVBoxLayout, QGroupBox, QMenu, QAction, QWidget
 from qtpy.QtCore import Qt
-from .motor import MotorMonitor, MotorControl
 from .views import AutoControl, AutoMonitor
 
 
@@ -73,7 +72,7 @@ class SwitchableMotorBox(QWidget):
 
         # Create action for toggling between pseudo and real motors
         toggle_action = QAction(
-            "Show Pseudo Motors" if self.showing_real_motors else "Show Real Motors",
+            ("Show Pseudo Motors" if self.showing_real_motors else "Show Real Motors"),
             self,
         )
         toggle_action.triggered.connect(self.toggle_motors_view)


### PR DESCRIPTION
Despite the branch title, this commit mostly fixes some instantiation issues with class hierarchies, where the super() MRO wasn't happening as I needed it to. Fix requires (unfortunately), class to be explicitly specified for calls to _initialize to prevent issues when classes don't actually re-implement a method, and some calls to self._initialize() resolve to trying to call a derived class that hasn't been instantiated yet.

Incidentally, implements better motor tuple displays for non-pseudomotors