### PR TITLE
Crash fixes

### DIFF
--- a/src/nbs_gui/main.py
+++ b/src/nbs_gui/main.py
@@ -134,20 +134,32 @@ def main(argv=None):
     SETTINGS.beamline_config_file = join(profile_dir, "beamline.toml")
 
     if exists(SETTINGS.gui_config_file):
-        with open(SETTINGS.gui_config_file, "r") as config_file:
-            SETTINGS.gui_config = toml.load(config_file)
+        try:
+            with open(SETTINGS.gui_config_file, "r") as config_file:
+                SETTINGS.gui_config = toml.load(config_file)
+        except Exception as e:
+            print(f"Error loading {SETTINGS.gui_config_file}:\n {e}")
+            raise e
     else:
         SETTINGS.gui_config = {}
 
     if not args.no_devices and exists(SETTINGS.object_config_file):
-        with open(SETTINGS.object_config_file, "r") as config_file:
-            SETTINGS.object_config = toml.load(config_file)
+        try:
+            with open(SETTINGS.object_config_file, "r") as config_file:
+                SETTINGS.object_config = toml.load(config_file)
+        except Exception as e:
+            print(f"Error loading {SETTINGS.object_config_file}:\n {e}")
+            raise e
     else:
         SETTINGS.object_config = {}
 
     if exists(SETTINGS.beamline_config_file):
-        with open(SETTINGS.beamline_config_file, "r") as config_file:
-            SETTINGS.beamline_config = toml.load(config_file)
+        try:
+            with open(SETTINGS.beamline_config_file, "r") as config_file:
+                SETTINGS.beamline_config = toml.load(config_file)
+        except Exception as e:
+            print(f"Error loading {SETTINGS.beamline_config_file}:\n {e}")
+            raise e
     else:
         SETTINGS.beamline_config = {}
 

--- a/src/nbs_gui/mainWidget.py
+++ b/src/nbs_gui/mainWidget.py
@@ -1,5 +1,5 @@
 from qtpy.QtWidgets import QTabWidget
-import pkg_resources
+from importlib.metadata import entry_points
 from .settings import SETTINGS
 
 
@@ -18,7 +18,7 @@ class TabViewer(QTabWidget):
 
         explicit_inclusion = len(tabs_to_include) > 0
         self.tab_dict = {}
-        tabs = pkg_resources.iter_entry_points("nbs_gui.tabs")
+        tabs = entry_points(group="nbs_gui.tabs")
         for tab_entry_point in tabs:
             # Call the modifier function with model and self (as parent) to get the QWidget
             if explicit_inclusion:

--- a/src/nbs_gui/widgets/header.py
+++ b/src/nbs_gui/widgets/header.py
@@ -4,6 +4,7 @@ from .queueControl import QtReQueueControls, QtReStatusMonitor
 from .serverControl import QueueServerControls
 from .planControl import PlanControls
 from ..views.motor import BeamlineMotorBars
+from ..views.status import StatusBox
 
 
 class MinimalHeader(QWidget):
@@ -33,6 +34,7 @@ class MinimalHeader(QWidget):
         # vbox.addLayout(hbox)
         layout.addLayout(vbox)
         running_plan = QtReRunningPlan(self.model.run_engine)
+
         layout.addWidget(running_plan)
 
         self.setLayout(layout)
@@ -67,5 +69,9 @@ class Header(QWidget):
         layout.addWidget(BeamlineMotorBars(self.model))
         running_plan = QtReRunningPlan(self.model.run_engine)
         layout.addWidget(running_plan)
+        plan_status = StatusBox(
+            self.model.user_status, "Plan Status", "PLAN_STATUS", ["status"]
+        )
+        layout.addWidget(plan_status)
 
         self.setLayout(layout)

--- a/src/nbs_gui/widgets/planSubmission.py
+++ b/src/nbs_gui/widgets/planSubmission.py
@@ -1,4 +1,3 @@
-import pkg_resources
 from qtpy.QtWidgets import (
     QWidget,
     QVBoxLayout,
@@ -15,6 +14,7 @@ from ..plans.planLoaders import PlanLoaderWidgetBase
 from ..plans.base import PlanWidgetBase
 from qtpy.QtCore import Signal, QObject
 from nbs_gui.widgets.timeEstimators import TimeEstimator
+from importlib.metadata import entry_points
 
 
 # Concepts of a plan submission model
@@ -31,7 +31,7 @@ class PlanSubmissionBase(QWidget):
         plans_to_exclude = config.get("gui", {}).get("plans", {}).get("exclude", [])
         explicit_inclusion = len(plans_to_include) > 0
 
-        plans = pkg_resources.iter_entry_points("nbs_gui.plans")
+        plans = entry_points(group="nbs_gui.plans")
         print("[PlanSubmission] Loading plan entry points")
         for plan_entry_point in plans:
             if explicit_inclusion:
@@ -219,7 +219,7 @@ class PlanLoadWidget(QWidget):
         )
         explicit_inclusion = len(plans_to_include) > 0
 
-        plans = pkg_resources.iter_entry_points("nbs_gui.plan_loaders")
+        plans = entry_points(group="nbs_gui.plan_loaders")
         # Need to load only desired plans from config file!
         for plan_entry_point in plans:
             if explicit_inclusion:

--- a/src/nbs_gui/widgets/queueControl.py
+++ b/src/nbs_gui/widgets/queueControl.py
@@ -120,12 +120,25 @@ class QtReQueueControls(QWidget):
             )
 
     def _pb_queue_exec_one_clicked(self):
+        if self.model.re_manager_status.get("manager_state", None) != "idle":
+            QMessageBox.critical(
+                self,
+                "Queue Control Error",
+                "RE Manager is not idle. Please stop the queue before executing one plan.",
+                QMessageBox.Ok,
+            )
+            return
         try:
             resp = self.model._client.item_remove(pos="front")
             if resp["success"]:
                 self.model._client.item_execute(resp["item"])
         except Exception as ex:
-            print(f"Exception: {ex}")
+            QMessageBox.critical(
+                self,
+                "Queue Control Error",
+                f"Failed to execute one plan: {str(ex)}",
+                QMessageBox.Ok,
+            )
 
     def _cb_queue_autostart_state_changed(self, state):
         try:

--- a/src/nbs_gui/widgets/timeEstimators.py
+++ b/src/nbs_gui/widgets/timeEstimators.py
@@ -1,4 +1,4 @@
-import pkg_resources
+from importlib.metadata import entry_points
 
 
 def load_time_estimators():
@@ -24,9 +24,7 @@ def load_time_estimators():
         # Load additional estimators from entry points
         try:
 
-            for entry_point in pkg_resources.iter_entry_points(
-                "nbs_bl.time_estimators"
-            ):
+            for entry_point in entry_points(group="nbs_bl.time_estimators"):
                 estimator = entry_point.load()
                 if callable(estimator):
                     time_estimators[entry_point.name] = estimator

--- a/src/nbs_gui/window.py
+++ b/src/nbs_gui/window.py
@@ -6,7 +6,7 @@ from .mainWidget import TabViewer
 from .confEdit import ConfigEditor
 from qtpy.QtWidgets import QVBoxLayout, QWidget, QAction
 
-import pkg_resources
+from importlib.metadata import entry_points
 
 
 class MainWindow(Window):
@@ -108,7 +108,7 @@ class MainWindow(Window):
     @staticmethod
     def load_header_from_entrypoint(entrypoint_name):
         """Load the header widget from an entry point"""
-        for entry_point in pkg_resources.iter_entry_points(group="nbs_gui.widgets"):
+        for entry_point in entry_points(group="nbs_gui.widgets"):
             if entry_point.name == entrypoint_name:
                 return entry_point.load()
         return Header


### PR DESCRIPTION
# Crashes due to Toml files
Better toml error messages when a config file is malformed

# Crashes due to non-idle run engine
Pre-emptively fixed some cases where you could try to execute a plan while the run engine is not idle

# Clean up deprecations
Switched entrypoints from pkg_resources (deprecated) to importlib