### PR TITLE
Removing PlanStatus widget from header, not supposed to be in master yet

### DIFF
--- a/src/nbs_gui/widgets/header.py
+++ b/src/nbs_gui/widgets/header.py
@@ -69,9 +69,5 @@ class Header(QWidget):
         layout.addWidget(BeamlineMotorBars(self.model))
         running_plan = QtReRunningPlan(self.model.run_engine)
         layout.addWidget(running_plan)
-        plan_status = StatusBox(
-            self.model.user_status, "Plan Status", "PLAN_STATUS", ["status"]
-        )
-        layout.addWidget(plan_status)
 
         self.setLayout(layout)


### PR DESCRIPTION
Just removing a widget that needs to wait for the topic branch